### PR TITLE
update before_validation to comply with ActiveRecord 5.1 deprecations

### DIFF
--- a/lib/blind_index/model.rb
+++ b/lib/blind_index/model.rb
@@ -49,7 +49,12 @@ module BlindIndex
         end
 
         if callback
-          before_validation method_name, if: -> { changes.key?(attribute.to_s) }
+          if ActiveRecord::VERSION::STRING >= "5.1"
+            before_validation method_name, if: :"will_save_change_to_#{attribute}?"
+          else
+            before_validation method_name, if: -> { changes.key?(attribute.to_s) }
+          end
+
         end
 
         # use include so user can override


### PR DESCRIPTION
Hey Andrew, can't remember if I already sent you fan mail about this gem, so if I haven't, thank you for all your work once again.

ActiveModel::Dirty in Rails 5.1 introduces some deprecations related to changed attributes, so [this method](https://github.com/ankane/blind_index/blob/master/lib/blind_index/model.rb#L52) makes things unhappy.

```
        if callback
          before_validation method_name, if: -> { changes.key?(attribute.to_s) }
        end
```

This fixes that by changing before for AR 5.1+. I wish I could introduce a test for this but I'm not sure that's possible. FWIW, all the tests in my project are passing when using this fork.

Hope this is alright. Please let me know if you'd like this handled differently. Appreciate your help!