### PR TITLE
Support querying encrypted attribute by array

### DIFF
--- a/lib/blind_index/extensions.rb
+++ b/lib/blind_index/extensions.rb
@@ -7,7 +7,13 @@ module BlindIndex
         if has_blind_indexes?
           hash.each do |key, _|
             if key.respond_to?(:to_sym) && (bi = klass.blind_indexes[key.to_sym]) && !new_hash[key].is_a?(ActiveRecord::StatementCache::Substitute)
-              new_hash[bi[:bidx_attribute]] = BlindIndex.generate_bidx(new_hash.delete(key), bi)
+              value = new_hash.delete(key)
+              new_hash[bi[:bidx_attribute]] =
+                if value.instance_of?(Array)
+                  value.map { |v| BlindIndex.generate_bidx(v, bi) }
+                else
+                  BlindIndex.generate_bidx(value, bi)
+                end
             end
           end
         end
@@ -30,7 +36,13 @@ module BlindIndex
         if has_blind_indexes?(klass)
           hash.each do |key, _|
             if key.respond_to?(:to_sym) && (bi = klass.blind_indexes[key.to_sym]) && !new_hash[key].is_a?(ActiveRecord::StatementCache::Substitute)
-              new_hash[bi[:bidx_attribute]] = BlindIndex.generate_bidx(new_hash.delete(key), bi)
+              value = new_hash.delete(key)
+              new_hash[bi[:bidx_attribute]] =
+                if value.instance_of?(Array)
+                  value.map { |v| BlindIndex.generate_bidx(v, bi) }
+                else
+                  BlindIndex.generate_bidx(value, bi)
+                end
             end
           end
         end

--- a/test/blind_index_test.rb
+++ b/test/blind_index_test.rb
@@ -26,6 +26,12 @@ class BlindIndexTest < Minitest::Test
     assert User.where(email: "test@example.org").first
   end
 
+  def test_where_array
+    create_user
+    create_user(email: "test2@example.org")
+    assert_equal 2, User.where(email: ["test@example.org", "test2@example.org"]).count
+  end
+
   def test_where_string_key
     create_user
     assert User.where({"email" => "test@example.org"}).first


### PR DESCRIPTION
This PR makes it possible to query an encrypted attribute by an `Array` of values so running `User.where(email: ["test@example.org", "test2@example.org"])` will generate `bidx` for every member of an `Array` and not for `Array` itself.