### PR TITLE
Win: argon2 2.0.2 was released

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ Add this line to your application’s Gemfile:
 gem 'blind_index'
 ```
 
-On Windows, also add:
-
-```ruby
-gem 'argon2', git: 'https://github.com/technion/ruby-argon2.git', submodules: true
-```
-
-Until `argon2 > 2.0.2` is released.
-
 ## Getting Started
 
 > Note: Your model should already be set up with Lockbox or attr_encrypted. The examples are for a `User` model with `encrypts :email` or `attr_encrypted :email`. See the full examples for [Lockbox](https://ankane.org/securing-user-emails-lockbox) and [attr_encrypted](https://ankane.org/securing-user-emails-in-rails) if needed.

--- a/blind_index.gemspec
+++ b/blind_index.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "activesupport", ">= 5"
-  spec.add_dependency "argon2", ">= 2"
+  spec.add_dependency "argon2", ">= 2.0.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I just saw this comment in the README about Win depending on argon2 master branch fix for Windows until argon2 2.0.2 is released and realized that argon2 2.0.2 was already out.

PS I haven't tested this on Windows! Feel free to choose not to merge this PR immediately due to this. I'm sorry, I don't have Windows machine on disposal.