### PR TITLE
Add the column specified in `blind_index` to` filter_attributes`.

### DIFF
--- a/lib/blind_index/model.rb
+++ b/lib/blind_index/model.rb
@@ -36,6 +36,12 @@ module BlindIndex
         key ||= -> { BlindIndex.index_key(table: try(:table_name) || collection_name.to_s, bidx_attribute: bidx_attribute, master_key: options[:master_key], encode: false) }
 
         class_eval do
+          activerecord = defined?(ActiveRecord) && self < ActiveRecord::Base
+
+          if activerecord && ActiveRecord::VERSION::MAJOR >= 6
+            self.filter_attributes += [/\A#{Regexp.escape(bidx_attribute)}\z/]
+          end
+
           @blind_indexes ||= {}
 
           unless respond_to?(:blind_indexes)
@@ -69,8 +75,6 @@ module BlindIndex
           end
 
           if callback
-            activerecord = defined?(ActiveRecord) && self < ActiveRecord::Base
-
             # TODO reuse module
             m = Module.new do
               define_method "#{attribute}=" do |value|

--- a/test/blind_index_test.rb
+++ b/test/blind_index_test.rb
@@ -342,6 +342,23 @@ class BlindIndexTest < Minitest::Test
     assert Group.joins(:users).where(users: {email: "test@example.org"}).first
   end
 
+  def test_inspect_filter_attributes
+    skip if mongoid? || ActiveRecord::VERSION::STRING.to_f < 6
+
+    previous_value = User.filter_attributes
+
+    begin
+      user = create_user
+      assert_includes user.inspect, "email_bidx: [FILTERED]"
+
+      # Active Record still shows nil for filtered attributes
+      user = create_user(email: nil)
+      assert_includes user.inspect, "name: nil"
+    ensure
+      User.filter_attributes = previous_value
+    end
+  end
+
   private
 
   def random_key


### PR DESCRIPTION
Thanks for creating such a nice gem.
I found one suggestion while using this gem in my project, so I created this PR.

## Summary

I want the index column of the column specified by `blind_index` to be filtered by` rails console`. Therefore, add the column specified by `blind_index` to` filter_attributes`.

This is based on the gem'lockbox' approach.
See: https://github.com/ankane/lockbox/blob/ea97e8afb512e4b61b472361779f4f6aa7dddc3d/lib/lockbox/model.rb#L62

This PR may resolve the following issue https://github.com/ankane/blind_index/issues/50