### PR TITLE
Prevent timestamp modifications on backfill

### DIFF
--- a/lib/blind_index/backfill.rb
+++ b/lib/blind_index/backfill.rb
@@ -94,7 +94,7 @@ module BlindIndex
       if records.any?
         with_transaction do
           records.each do |record|
-            record.save!(validate: false)
+            record.save!(validate: false, touch: false)
           end
         end
       end


### PR DESCRIPTION
This PR prevents timestamps from being updated during the blind_index backfill.