### PR TITLE
fix mongoid integration around #find_or_create_by

### DIFF
--- a/lib/blind_index/mongoid.rb
+++ b/lib/blind_index/mongoid.rb
@@ -5,6 +5,9 @@ module BlindIndex
 
       def expr_query(criterion)
         if criterion.is_a?(Hash) && klass.respond_to?(:blind_indexes)
+          # Mongoid's find_or_create_by reuses the same hash object for the lookup and the subsequent
+          # create; on Ruby 3.4+, the keyword-argument hash is no longer copied between delegations.
+          criterion = criterion.dup
           criterion.keys.each do |key|
             key_sym = (key.is_a?(::Mongoid::Criteria::Queryable::Key) ? key.name : key).to_sym
 

--- a/test/blind_index_test.rb
+++ b/test/blind_index_test.rb
@@ -20,6 +20,19 @@ class BlindIndexTest < Minitest::Test
     assert_equal user, User.find_or_create_by(email: "test@example.org")
   end
 
+  def test_find_or_create_by_creates_with_attribute
+    user = User.find_or_create_by(email: "new@example.org")
+    assert_equal "new@example.org", user.email
+    assert User.where(email: "new@example.org").first
+  end
+
+  def test_where_does_not_mutate_criteria
+    create_user
+    criteria = {email: "test@example.org"}
+    User.where(criteria).first
+    assert_equal({email: "test@example.org"}, criteria)
+  end
+
   def test_delete_by
     skip if mongoid?
 


### PR DESCRIPTION
`blind_index` mutates the hash passed in conditions, and in ruby 3.4, the hash passed to the "find" portion is the same passed to "create".

The hash is the same due to a change in behaviour in keyword argument forwarding, which preserves the objects instead of making a copy.